### PR TITLE
bump to use new version

### DIFF
--- a/mac-keyboard.js
+++ b/mac-keyboard.js
@@ -14,7 +14,7 @@
 
 'use strict'
 
-var $ = require('NodObjC');
+var $ = require('nodobjc');
 $.framework('Cocoa');
 
 var pool;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mac-keyboard",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Enables you to create virtual keyboard input on Mac OS X using Cocoa.",
   "author": {
     "name": "Sveinn Floki Gudmundsson",
@@ -28,7 +28,7 @@
     "node": "*"
   },
   "dependencies": {
-    "NodObjC": "~1.0.0"
+    "nodobjc": "2.1.0"
   },
   "license": "MIT",
   "homepage": "https://github.com/ctwhome/node-mac-keyboard",


### PR DESCRIPTION
This was broken as npm no longer allows capital letters in package name.
